### PR TITLE
all reducers should have an error state

### DIFF
--- a/cms/src/scenes/Account/state/auth.js
+++ b/cms/src/scenes/Account/state/auth.js
@@ -175,6 +175,7 @@ export function load() {
  */
 const INITIAL_STATE = {
   loaded: false,
+  error: null,
   isLoading: false,
   role: null,
   token: null,

--- a/cms/src/scenes/Account/state/auth.test.js
+++ b/cms/src/scenes/Account/state/auth.test.js
@@ -19,6 +19,7 @@ describe('authReducer', () => {
   const initialState = {
     loaded: false,
     isLoading: false,
+    error: null,
     role: null,
     token: null,
     hydrated: true

--- a/cms/src/scenes/Blog/state/blog.js
+++ b/cms/src/scenes/Blog/state/blog.js
@@ -10,24 +10,17 @@ export const FETCH_POSTS_SUCCESS = 'FETCH_POSTS_SUCCESS';
 export const FETCH_POSTS_FAIL = 'FETCH_POSTS_FAIL';
 
 // Fetch Articles Action
-
-export function requestPosts() {
+export const requestPosts = () => {
   return { type: FETCH_POSTS_REQUEST };
-}
+};
 
-// export function receivePosts(json) {
-//   return {
-//     type: FETCH_POSTS_SUCCESS,
-//     result: json
-//   };
-// }
 const receivePosts = (response) => ({
   type: FETCH_POSTS_SUCCESS,
   posts: response.body
 });
 const receivePostsFailed = (err) => ({
   type: FETCH_POSTS_FAIL,
-  message: err
+  error: err
 });
 export function fetchPosts(data) {
   return dispatch => {
@@ -70,16 +63,16 @@ export const FETCH_POST_REQUEST = 'FETCH_POST_REQUEST';
 export const FETCH_POST_SUCCESS = 'FETCH_POST_SUCCESS';
 export const FETCH_POST_FAIL = 'FETCH_POST_FAIL';
 
-export function requestPost() {
+export const requestPost = () => {
   return { type: FETCH_POST_REQUEST };
-}
+};
 const receivePost = (response) => ({
   type: FETCH_POST_SUCCESS,
   payload: response.body
 });
 const receivePostFailed = (err) => ({
   type: FETCH_POST_FAIL,
-  message: err
+  error: err
 });
 export function fetchPost(slug) {
   return dispatch => {
@@ -99,7 +92,7 @@ export function fetchPost(slug) {
 
 export const INITIAL_STATE = {
   isLoading: false,
-  error: undefined,
+  error: null,
   posts: [],
   selectedPost: {}
 };

--- a/cms/src/scenes/Dashboard/scenes/Articles/state/article.js
+++ b/cms/src/scenes/Dashboard/scenes/Articles/state/article.js
@@ -62,7 +62,7 @@ const receiveArticle = (response) => ({
 });
 const receiveArticleFailed = (err) => ({
   type: at.SELECT_ARTICLE_FAIL,
-  message: err
+  error: err
 });
 export function selectArticle(articleId) {
   return (dispatch) => {
@@ -232,6 +232,7 @@ export function updateArticle(articleData) {
 export const INITIAL_STATE = {
   isLoading: false,
   message: undefined,
+  error: null,
   articles: [],
   current: {},
   isEditing: false
@@ -245,6 +246,7 @@ export const INITIAL_STATE = {
 export default function article(state = INITIAL_STATE, action = {}) {
   switch (action.type) {
     case at.FETCH_ARTICLES_REQUEST:
+    case at.CREATE_ARTICLE_REQUEST:
       return {
         ...state,
         isLoading: true
@@ -256,24 +258,13 @@ export default function article(state = INITIAL_STATE, action = {}) {
         articles: action.result
       };
     case at.FETCH_ARTICLES_FAIL:
+    case at.CREATE_ARTICLE_FAIL:
       return {
         ...state,
         isLoading: false,
-        message: action.error
-      };
-    case at.CREATE_ARTICLE_REQUEST:
-      return {
-        ...state,
-        isLoading: false,
-        message: action.error
+        error: action.error
       };
     case at.CREATE_ARTICLE_SUCCESS:
-      return {
-        ...state,
-        isLoading: false,
-        message: action.error
-      };
-    case at.CREATE_ARTICLE_FAIL:
       return {
         ...state,
         isLoading: false,

--- a/cms/src/scenes/Dashboard/scenes/Users/state/siteUsers.js
+++ b/cms/src/scenes/Dashboard/scenes/Users/state/siteUsers.js
@@ -43,7 +43,7 @@ export function loadSiteUsers(data) {
 const INITIAL_STATE = {
   isLoading: false,
   users: [],
-  error: undefined
+  error: null
 };
 
 export default function siteUsersReducer(state = INITIAL_STATE, action) {


### PR DESCRIPTION
This adds the error field on the initial state. Now all reducers take action.error for the error instead of a mixture of error / message.
